### PR TITLE
change: fetch changes from ncc_v0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 .spec
 .pyc
 tools/ncc/*/
+datasets/*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ or use aliyun's source if you are in China
 pip3 install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple/
 ```
 
-* [Download nncase](https://github.com/kendryte/nncase/releases/tag/v0.1.0-rc5) and unzip it to `tools/ncc/ncc_v0.1`, and the executable path is `tools/ncc/ncc_v0.1/ncc`
+* [Download nncase](https://github.com/kendryte/nncase/releases/tag/v0.2.0-beta4) and unzip it to `tools/ncc/ncc_v0.2`, and the executable path is `tools/ncc/ncc_v0.2/ncc`
 * `python3 train.py init`
 * Edit `instance/config.py` according to your hardware
 * Prepare dataset, in the `datasets` directory has some example datasets, input size if `224x224`

--- a/tools/ncc/README.md
+++ b/tools/ncc/README.md
@@ -1,8 +1,8 @@
 
 
 
-you can download ncc v0.1.0 from https://github.com/kendryte/nncase/releases/tag/v0.1.0-rc5
+you can download ncc v0.2.0 from https://github.com/kendryte/nncase/releases/tag/v0.2.0-beta4
 
-and rename to `ncc_v0.1`
+and rename to `ncc_v0.2`, and the executable path is `tools/ncc/ncc_v0.2/ncc`
 
 

--- a/train/__init__.py
+++ b/train/__init__.py
@@ -350,7 +350,8 @@ class Train():
             @ncc_path ncc 可执行程序路径
             @return (ok, msg) 是否出错 (bool, str)
         '''
-        p =subprocess.Popen([ncc_path, "-i", "tflite", "-o", "k210model", "--dataset", images_path, tf_lite_path, kmodel_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen([ncc_path, "compile", tf_lite_path, kmodel_path, "-i", "tflite", "-o", "kmodel", "-t",
+                              "k210", "--dataset", images_path, ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
             output, err = p.communicate( )
             res = p.returncode

--- a/train/config_template.py
+++ b/train/config_template.py
@@ -6,8 +6,8 @@ curr_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 # kmodel convert
-                 # "/ncc/ncc"  # download from https://github.com/kendryte/nncase/releases/tag/v0.1.0-rc5
-ncc_kmodel_v3 =  os.path.join(curr_dir, "..", "tools", "ncc", "ncc_v0.1/ncc")  
+# "/ncc/ncc"  # download from https://github.com/kendryte/nncase/releases/tag/v0.2.0-beta4
+ncc_kmodel_v3 = os.path.join(curr_dir, "..", "tools", "ncc", "ncc_v0.2/ncc")
 sample_image_num = 20       # convert kmodel sample image (for quantizing)
 
 # train


### PR DESCRIPTION
ncc v0.2 brings a destructive update, which makes the original code unable to be compiled into kmodel. 
This patch follows up the update of ncc.

*NNCase v0.2.0*

Major changes

    Add ONNX importer (thanks to @aclex 's contribution)
    Add fused unary op for uint8 inference
    Add any unary activation fusion for KPU ops
    Add KPU matmul
    Support accelerating dilated conv2d by KPU
    Add --weights-quantize-threshold, --output-quantize-threshold and --no-quantized-binary (See usage)
    Add L2 based calibration methods
    Support Slice
    Support Mac OS


Bugs fixes

    Fix a bug in binary ops optimization
    Fix a bug in k210 pooling optimization
    Some bug fixes in tflite and onnx importer

